### PR TITLE
Feat: health checks and request timeouts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,20 @@ Requirements::
     KLANT_CODE = <pass>
     SLACK_WEBHOOK_URL = https://hooks.slack.com/services/T../B../a..
     TIMEZONE = Europe/Amsterdam  # used by Docker image
+    HEALTH_FILE = <file_path>
 
 Building::
 
     docker build --build-arg=GITVERSION=$(git describe --always) \
         -t $NAMESPACE/alert-group-nl-log2slack .
+
+Health checks::
+
+    #!/bin/sh
+    now=$(date +%s)
+    updated=$(stat -c%Y "$HEALTH_FILE" 2>/dev/null || echo 0)
+    if [ $((now - updated)) -gt 900 ]; then
+        echo "No updates in the last $((now - updated)) seconds" >&2
+        exit 1
+    fi
+    exit 0 


### PR DESCRIPTION
This PR introduces the option to set a `HEALTH_FILE`. The script will update a timestamp stored in this file every time it checks for any new alerts with the alarm API.

I've also added some timeouts to all `requests.(get|post)()` and `session.(get|post)()`.

The `HEALTH_FILE` can then be used to perform health checks, like the example script below:

```sh
#!/bin/sh
now=$(date +%s)
updated=$(stat -c%Y "$HEALTH_FILE" 2>/dev/null || echo 0)
if [ $((now - updated)) -gt 60 ]; then
  echo "No updates in the last $((now - updated)) seconds" >&2
  exit 1
fi
exit 0
```